### PR TITLE
Switch default Newsroom type to blank, with selection still required.

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -133,8 +133,8 @@ collections:
           required: true,
           widget: 'select',
           options:
-            ['Funding Opportunities', 'Speech', 'Testimonial', 'Newsletter'],
-          default: 'Newsletter',
+            ['','Funding Opportunities', 'Speech', 'Testimonial', 'Newsletter'],
+          default: '',
         }
       - {
           label: 'NCD Policy Areas',


### PR DESCRIPTION
This change adds a blank default option to the Newsroom Type selection, so that new Newsroom pages won't inadvertently default to "Newsletter".