### PR TITLE
Fix faq page permalink

### DIFF
--- a/resources/faq.md
+++ b/resources/faq.md
@@ -1,6 +1,6 @@
 ---
 layout: single-page
-permalink: /resources/faq
+permalink: /resources/faq/
 title: FAQ
 description: Frequently asked questions regarding the NCD.
 ---


### PR DESCRIPTION
Missed a trailing slash on the FAQ page permalink route