### PR TITLE
Suppress display of author in paginated collection items

### DIFF
--- a/_includes/paginated-collection-item.html
+++ b/_includes/paginated-collection-item.html
@@ -28,9 +28,7 @@
       </h3>
       <div class="text-base margin-bottom-2">
         <div class="margin-top-neg-105">
-          {% if include.post.author %} By
-          <span class="text-bold"> {{ include.post.author }} </span>
-          · {% endif %} {{ include.post.date | date: '%B %d, %Y' }}
+          {{ include.post.date | date: '%B %d, %Y' }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This change removes the author field (which was previously shown when it existed) from paginated collection items.