### PR TITLE
Add paginated policy area pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,7 @@ collections:
     output: true
     permalink: /meeting/:name/
   policy-areas:
-    output: true
+    output: false
     permalink: /policy-areas/:name/
   publications:
     output: true

--- a/_layouts/policy-area.html
+++ b/_layouts/policy-area.html
@@ -1,0 +1,23 @@
+---
+layout: wide
+---
+
+<div class="grid-container">
+  <div class="grid-row">
+    <div class="desktop:grid-col-12 usa-prose">
+      {%
+        include collection-header.html
+        title=page.policy_area
+      %}
+      <div>{{content}}</div>
+      {% for post in paginator.posts %}
+        {%
+          include paginated-collection-item.html
+          post=post
+        %}
+      {% endfor %}
+      <!-- Pagination links -->
+      {% include paginator.html %}
+    </div>
+  </div>
+</div>

--- a/_layouts/policy-area.html
+++ b/_layouts/policy-area.html
@@ -7,7 +7,7 @@ layout: wide
     <div class="desktop:grid-col-12 usa-prose">
       {%
         include collection-header.html
-        title=page.policy_area
+        title=page.title
       %}
       <div>{{content}}</div>
       {% for post in paginator.posts %}

--- a/_plugins/policy_areas.rb
+++ b/_plugins/policy_areas.rb
@@ -1,0 +1,11 @@
+class CustomTags < Jekyll::Generator
+  def generate(site)
+    site.posts.docs.each do |doc|
+      if doc.data['policy_areas']
+        doc.data['policy_areas'].each do |area|
+          doc.tags.push(area)
+        end
+      end
+    end
+  end
+end

--- a/policy-areas/civil-rights.md
+++ b/policy-areas/civil-rights.md
@@ -1,0 +1,8 @@
+---
+title: Civil Rights
+layout: policy-area
+policy_area: Civil Rights
+pagination:
+  enabled: true
+  collection: all
+---

--- a/policy-areas/civil-rights.md
+++ b/policy-areas/civil-rights.md
@@ -1,8 +1,8 @@
 ---
 title: Civil Rights
 layout: policy-area
-policy_area: Civil Rights
 pagination:
   enabled: true
-  collection: all
+  tag:
+    - "Civil Rights"
 ---

--- a/policy-areas/crpd.md
+++ b/policy-areas/crpd.md
@@ -1,0 +1,8 @@
+---
+title: CRPD
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "CRPD"
+---

--- a/policy-areas/cultural-diversity.md
+++ b/policy-areas/cultural-diversity.md
@@ -1,0 +1,8 @@
+---
+title: Cultural Diversity
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Cultural Diversity"
+---

--- a/policy-areas/education.md
+++ b/policy-areas/education.md
@@ -1,0 +1,8 @@
+---
+title: Education
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Education"
+---

--- a/policy-areas/emergency-management.md
+++ b/policy-areas/emergency-management.md
@@ -1,0 +1,8 @@
+---
+title: Emergency Management
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Emergency Management"
+---

--- a/policy-areas/employment.md
+++ b/policy-areas/employment.md
@@ -1,0 +1,8 @@
+---
+title: Employment
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Employment"
+---

--- a/policy-areas/financial-assistance-and-incentives.md
+++ b/policy-areas/financial-assistance-and-incentives.md
@@ -1,0 +1,8 @@
+---
+title: Financial Assistance & Incentives
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Financial Assistance & Incentives"
+---

--- a/policy-areas/health-care.md
+++ b/policy-areas/health-care.md
@@ -1,0 +1,8 @@
+---
+title: Health Care
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Health Cares"
+---

--- a/policy-areas/housing.md
+++ b/policy-areas/housing.md
@@ -1,0 +1,8 @@
+---
+title: Housing
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Housing"
+---

--- a/policy-areas/international.md
+++ b/policy-areas/international.md
@@ -1,0 +1,8 @@
+---
+title: International
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "International"
+---

--- a/policy-areas/long-term-services-and-support.md
+++ b/policy-areas/long-term-services-and-support.md
@@ -1,0 +1,8 @@
+---
+title: Long Term Services & Support
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Long Term Services & Support"
+---

--- a/policy-areas/technology.md
+++ b/policy-areas/technology.md
@@ -1,0 +1,8 @@
+---
+title: Technology
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Technology"
+---

--- a/policy-areas/transportation.md
+++ b/policy-areas/transportation.md
@@ -1,0 +1,8 @@
+---
+title: Transportation
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Transportation"
+---

--- a/policy-areas/youth-perspectives.md
+++ b/policy-areas/youth-perspectives.md
@@ -1,0 +1,8 @@
+---
+title: Youth Perspectives
+layout: policy-area
+pagination:
+  enabled: true
+  tag:
+    - "Youth Perspectives"
+---


### PR DESCRIPTION
This change introduces paginated policy area pages which include all pages assigned a given policy area. These pages are not yet linked in navigation or elsewhere but are published at URLs with paths like 

- /policy-areas/civil-rights/
- /policy-areas/financial-assistance-and-incentives/
- /policy-areas/technology/

etc.